### PR TITLE
support stylus-lemonade plugin

### DIFF
--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -98,6 +98,14 @@ module.exports = function(grunt) {
       s.set(key, value);
     });
 
+    try {
+      s.plugin('stylus-lemonade', {
+        image_path:  'public/images/',
+        sprite_path: 'public/images/',
+        sprite_url:  '/images/'
+      });
+    } catch(e) {}
+
     s.render(function(err, css) {
       if (err) {
         grunt.log.error(err);


### PR DESCRIPTION
optional support for third-party stylus plugin "stylus-lemonade"; if present, grunt-contrib-stylus will support it, but it is not required.

i am using this with [the towerjs project here](https://github.com/viatropos/tower/pull/360)
