### PR TITLE
Auto compression

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,14 @@ module.exports = function(grunt) {
           compress: true,
           flatten: true
         }
+      },
+      autocompress: {
+        files: {
+          'tmp/autocompress.css': 'test/fixtures/stylus.styl',
+        },
+        options: {
+          paths: ['test/fixtures/include']
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Adjusts the folder structure when compiled to the destination directory. When no
 
 #### compress
 Type: `Boolean`
-Default: false
+Default: true
 
 Specifies if we should compress the compiled css.
 

--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -76,6 +76,13 @@ module.exports = function(grunt) {
     delete options.basePath;
     delete options.flatten;
 
+    // Compress output by default but never in debug mode
+    if (grunt.option('debug')) {
+      options.compress = false;
+    } else if (options.compress === undefined) {
+      options.compress = true;
+    }
+
     var srcCode = grunt.file.read(srcFile);
     var s = require('stylus')(srcCode);
 

--- a/test/expected/autocompress.css
+++ b/test/expected/autocompress.css
@@ -1,0 +1,1 @@
+body{font:Helvetica;font-size:10px}

--- a/test/stylus_test.js
+++ b/test/stylus_test.js
@@ -31,5 +31,16 @@ exports.stylus = {
     test.deepEqual(expected, actual, 'should individually compile files (to flat structure)');
 
     test.done();
+  },
+  autocompress: function(test) {
+    'use strict';
+
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/autocompress.css');
+    var expected = grunt.file.read('test/expected/autocompress.css');
+    test.equal(expected, actual, 'output should be compressed when `compress` option not defined');
+
+    test.done();
   }
 };


### PR DESCRIPTION
Stylus will compress output by default (when `compress` option not defined in Gruntfile) but never in debug mode (when `--debug` flag passed to `grunt`).
