### PR TITLE
use previous version of stylus.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "stylus": "~0.31.0",
+    "stylus": "~0.30.0",
     "nib": "~0.9.0",
     "grunt-lib-contrib": "~0.4.0"
   },


### PR DESCRIPTION
v0.31 breaks existing code due to precision and unit conversion issues and needs to be better tested before using in production.
