### PR TITLE
tracking changes to expose compile method directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "url": "https://github.com/gruntjs/grunt-contrib-stylus/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "grunt.js",
+  "main": "./tasks/lib/stylus.js",
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/tasks/lib/stylus.js
+++ b/tasks/lib/stylus.js
@@ -14,15 +14,18 @@ var stylus = require('stylus');
 exports.init = function(grunt) {
   var exports = {};
 
-  exports.compile = function(srcFile, options, callback) {
+  exports.compileFile = function(srcFile, options, callback) {
     options = grunt.util._.extend({filename: srcFile}, options);
 
+    exports.compile(grunt.file.read(srcFile), options, callback);
+  };
+
+  exports.compile = function(srcCode, options, callback) {
     // Never compress output in debug mode
     if (grunt.option('debug')) {
       options.compress = false;
     }
 
-    var srcCode = grunt.file.read(srcFile);
     var s = stylus(srcCode);
 
     grunt.util._.each(options, function(value, key) {

--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
 
       var compiled = [];
       grunt.util.async.concatSeries(srcFiles, function(file, next) {
-        stylus.compile(file, options, function(css, err) {
+        stylus.compileFile(file, options, function(css, err) {
           if (!err) {
             compiled.push(css);
             next(null);


### PR DESCRIPTION
This is more of a discussion pull request.  I've made a few modifications to this plugin in order to get it working as expected with grunt-bbb.

**Added tasks/lib/stylus.js**

This allows us to break out the functionality of compiling stylus.  I changed the signature from `compileStylus` to `compile` (for source) and `compileFile` (for files).

**Modified package.json**

Changed the `main` property in package.json to point to `tasks/lib/stylus.js`.  This allows an external developer to simply require and init the plugin to access the methods.
