### PR TITLE
Reference correct Gruntfile.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "url": "https://github.com/gruntjs/grunt-contrib-stylus/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "grunt.js",
+  "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
The `package.json` file references `grunt.js` instead of `Gruntfile.js` - this breaks node modules that read the `package.json` file and load the files inside, since the file doesn't exist.
