### PR TITLE
Fixing a small mistake in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ stylus: {
       urlfunc: 'embedurl', // use embedurl('test.png') in our code to trigger Data URI embedding
       use: [
         require('fluidity') // use stylus plugin at compile time
-      ]
+      ],
       import: [    //  @import 'foo', 'bar/moo', etc. into every .styl file
       'foo',       //  that is compiled. These might be findable based on values you gave
       'bar/moo'    //  to `paths`, or a plugin you added under `use`


### PR DESCRIPTION
Super tiny change, there was a comma missing in the example
