### PR TITLE
Added notes about the linenos and firebug options in stylus

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,6 @@ Default: true
 
 Specifies if we should compress the compiled css. Compression is always disabled when `--debug` flag is passed to grunt.
 
-#### linenos
-Type: `Boolean`
-Default: false
-
-Specifies if the generated CSS file should contain comments indicating the corresponding stylus line.
-
-#### firebug
-Type: `Boolean`
-Default: false
-
-Specifies if the generated CSS file should contain debug info that can be used by the FireStylus Firebug plugin
-
 #### paths
 Type: `Array`
 

--- a/docs/stylus-options.md
+++ b/docs/stylus-options.md
@@ -6,6 +6,18 @@ Default: true
 
 Specifies if we should compress the compiled css. Compression is always disabled when `--debug` flag is passed to grunt.
 
+## linenos
+Type: `Boolean`
+Default: false
+
+Specifies if the generated CSS file should contain comments indicating the corresponding stylus line.
+
+## firebug
+Type: `Boolean`
+Default: false
+
+Specifies if the generated CSS file should contain debug info that can be used by the FireStylus Firebug plugin
+
 ## paths
 Type: `Array`
 


### PR DESCRIPTION
Since middleware options are passed through to stylus, you can use linenos and firebug (among others, but those were the two that made sense to specifically point out). I've added notes about them to the README.
