### PR TITLE
Workaround for hex-colors in include-option

### DIFF
--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -86,7 +86,11 @@ module.exports = function(grunt) {
         });
       } else if (key === 'define') {
         for (var defineName in value) {
-          s.define(defineName, value[defineName]);
+          var v = value[defineName];
+          if (v.indexOf('#') === 0) {
+            v = new stylus.nodes.Literal(v);
+          }
+          s.define(defineName, v);
         }
       } else if (key === 'import') {
         value.forEach(function(stylusModule) {


### PR DESCRIPTION
Hex-Colors didn't work for me, so I did this dirty fix. If there's a better option please tell me.

Now I can do:

``` javascript
stylus: {
    compile: {
      options: {
        define: {
           'colorone': "#E65213",
           'colortwo': "#E22E1D",
}
```

Before it results in "#E65213" in my CSS. Now the string will be unquoted.
