### PR TITLE
Loosen stylus dependency to support 0.38+

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "stylus": "~0.37.0",
+    "stylus": ">= 0.37.0 <1.0.0",
     "nib": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Stylus 0.38 is out, but PRs like #47, #48 and #50 are getting old.  Let's let package consumers opt in to new versions of stylus as soon (or late) as they like.  Grunt-browserify [takes this strategy](https://github.com/jmreidy/grunt-browserify/blob/master/package.json#L44).
