### PR TITLE
Bump Stylus to 0.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "stylus": "~0.37.0",
+    "stylus": "~0.38.0",
     "nib": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I'd much rather see relaxed dependency versions from #58 combined with [npm shrinkwrap](https://npmjs.org/doc/shrinkwrap.html) but I still need the [resolveURL fix](https://github.com/LearnBoost/stylus/commit/424ffbc43f6d56fed5647a99e485a7a6b5d26708) in 0.38
