### PR TITLE
Fix: 'resolve url' not working as expected

### DIFF
--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -93,6 +93,8 @@ module.exports = function(grunt) {
         value.forEach(function(stylusModule) {
           s.import(stylusModule);
         });
+      } else if (key === 'resolve url') {
+        s.define("url", stylus.resolver());
       } else {
         s.set(key, value);
       }


### PR DESCRIPTION
I was using the "resolve url" option in the stylus task but couldn't make it work as expected.

Looking into the code, I couldn't find any bit of code calling the "resolver" function.

Calling "stylus --resolve-url main.styl" did work as expected.

So I had a look at the basic stylus script, found the line related to resolveURL, and applied it to the stylus task.

Here is the code snippet from the basic stylus script: 

``` javascript
function usePlugins(style) {
[...]
  if (urlFunction) {
    style.define('url', stylus.url(urlFunction));
  } else if (resolveURL) {
    style.define('url', stylus.resolver()); //here is the line that has been copied to the task
  }
}
```
