### PR TITLE
Call `return` when short-circuiting due to empty src

### DIFF
--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
 
       if (srcFiles.length === 0) {
         // No src files, goto next target. Warn would have been issued above.
-        n();
+        return n();
       }
 
       var compiled = [];


### PR DESCRIPTION
I saw a strange error when I had a misnamed `src` property of my
Gruntfile.js; it stemmed from the `async` lib and was due to the fact
that in `tasks/stylus.js`, `n()` could be called multiple times in a
single iteration.  There's a check for empty `src` (`srcFiles.length === 0`),
which short-circuits and calls `n()`, but doesn't `return`. Then, later
down in the function, `n()` gets called again, confusing the `async`
lib.
