### PR TITLE
Warn on stylus errors

### DIFF
--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -105,8 +105,7 @@ module.exports = function(grunt) {
 
     s.render(function(err, css) {
       if (err) {
-        grunt.log.error(err);
-        grunt.fail.warn('Stylus failed to compile.');
+        grunt.log.warn(err);
 
         callback(css, true);
       } else {


### PR DESCRIPTION
Fixes #51. Alternative to #52 & #70 requested by @shama.

Log out stylus errors without exiting, and without an error code.  Not sure I like this.  I'm using grunt-contrib-stylus as part of the build script on a continuous deployment server.  It's a little scary that a deploy could go succeed when styles failed to build...

@shama @cowboy, are there other strategies for failing the build on stylus errors?  Parse the grunt output and look for errors?