### PR TITLE
Fixed an error when calling plugin with parameters via `use` directive

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,8 @@ module.exports = function(grunt) {
         },
         options: {
           use: [
-            testPlugin
+            testPlugin,
+            testPlugin()
           ]
         }
       },

--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -90,7 +90,8 @@ module.exports = function(grunt) {
       } else if (key === 'use') {
         value.forEach(function(func) {
           if (typeof func === 'function') {
-            s.use(func());
+            func = func.length ? func : func();
+            s.use(func);
           }
         });
       } else if (key === 'define') {


### PR DESCRIPTION
Hi there!
Currently, if you try to call any plugin with any number of parameters specified, you'll get an error.
In my case, I was trying to use [autoprefixer-stylus](https://github.com/jenius/autoprefixer-stylus) plugin in task shown below:

```
module.exports = function (grunt) {
  grunt.initConfig({
    stylus: {
      options: {
        use: [require('autoprefixer-stylus')('last 2 versions', 'ie 8', 'ie 9')]
      },
      ...
    }
  } );

  grunt.loadNpmTasks('grunt-contrib-stylus');
  grunt.registerTask('default', [ 'stylus' ]);
};
```

I've added test case and fixed an issue.
