### PR TITLE
Changed links from visionmedia to tj

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _Run this task with the `grunt stylus` command._
 
 Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
 
-This task comes preloaded with [nib](http://visionmedia.github.com/nib/).
+This task comes preloaded with [nib](http://tj.github.io/nib/).
 ### Options
 
 #### compress

--- a/docs/stylus-overview.md
+++ b/docs/stylus-overview.md
@@ -1,3 +1,3 @@
 Task targets, files and options may be specified according to the grunt [Configuring tasks](http://gruntjs.com/configuring-tasks) guide.
 
-This task comes preloaded with [nib](http://visionmedia.github.com/nib/).
+This task comes preloaded with [nib](http://tj.github.io/nib/).


### PR DESCRIPTION
nib is no longer available under http://visionmedia.github.com/nib/
