### PR TITLE
Relative destination 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 npm-debug.log
 tmp
-.idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,6 +180,21 @@ module.exports = function(grunt) {
           paths: ['test/fixtures/'],
           banner: '/* test css banner */\n'
         }
+      },
+      relativeDest: {
+        files: [{
+          expand: true,
+          relativeDest: '/out',
+          src: ['test/fixtures/relativeDest/relativeDest.styl'],
+          dest: 'tmp',
+          ext: '.css'
+        }, {
+          expand: true,
+          relativeDest: '../../',
+          src: ['test/fixtures/relativeDest/relativeDest.styl'],
+          dest: 'tmp',
+          ext: '.css'
+        }]
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,214 +10,223 @@
 
 module.exports = function(grunt) {
 
-  function testPlugin(param) {
-    param = param || 'nope';
+	function testPlugin(param) {
+		param = param || 'nope';
 
-    return function(style) {
-      style.define('test-plugin', param);
-    };
-  }
+		return function(style) {
+			style.define('test-plugin', param);
+		};
+	}
 
-  // Project configuration.
-  grunt.initConfig({
-    jshint: {
-      all: [
-        'Gruntfile.js',
-        'tasks/*.js',
-        '<%= nodeunit.tests %>'
-      ],
-      options: {
-        jshintrc: '.jshintrc'
-      }
-    },
+	// Project configuration.
+	grunt.initConfig({
+		jshint: {
+			all: [
+				'Gruntfile.js',
+				'tasks/*.js',
+				'<%= nodeunit.tests %>'
+			],
+			options: {
+				jshintrc: '.jshintrc'
+			}
+		},
 
-    // Before generating any new files, remove any previously-created files.
-    clean: {
-      test: ['tmp']
-    },
+		// Before generating any new files, remove any previously-created files.
+		clean: {
+			test: ['tmp']
+		},
 
-    // Configuration to be run (and then tested).
-    stylus: {
-      compile: {
-        files: {
-          'tmp/stylus.css': ['test/fixtures/stylus.styl'],
-          'tmp/concat.css': ['test/fixtures/stylus.styl', 'test/fixtures/stylus2.styl']
-        },
-        options: {
-          paths: ['test/fixtures/include'],
-          compress: true
-        }
-      },
-      nib: {
-        files: {
-          'tmp/nib_.css': 'test/fixtures/nib_/nib_.styl'
-        },
-        options: {
-          paths: ['test/fixtures/include']
-        }
-      },
-      autocompress: {
-        files: {
-          'tmp/autocompress.css': 'test/fixtures/stylus.styl'
-        },
-        options: {
-          paths: ['test/fixtures/include']
-        }
-      },
-      plugin: {
-        files: {
-          'tmp/plugin.css': 'test/fixtures/plugin/plugin.styl'
-        },
-        options: {
-          use: [
-            testPlugin,
-            function () {
-              return testPlugin('yep');
-            }
-          ]
-        }
-      },
-      embedurl: {
-        files: {
-          'tmp/embedurl.css': 'test/fixtures/embedurl/embedurl.styl'
-        },
-        options: {
-          urlfunc: 'embedurl'
-        }
-      },
-      embedurlObj: {
-        files: {
-          'tmp/embedurlObj.css': 'test/fixtures/embedurl/embedurl.styl'
-        },
-        options: {
-          urlfunc: {
-            name: 'embedurl'
-          }
-        }
-      },
-      urlfuncOpts: {
-        files: {
-          'tmp/embedurlOpts.css': 'test/fixtures/embedurl/embedurlOpts.styl'
-        },
-        options: {
-          urlfunc: {
-            name: 'embedurl',
-            limit: 10,
-            paths: []
-          }
-        }
-      },
-      urlfuncLimitFalse: {
-        files: {
-          'tmp/urlfuncLimitFalse.css': 'test/fixtures/embedurl/urlfuncLimitFalse.styl'
-        },
-        options: {
-          urlfunc: {
-            name: 'embedurl',
-            limit: false,
-            paths: []
-          }
-        }
-      },
-      relative: {
-        files: {
-          'tmp/relative.css': 'test/fixtures/relative/relative.styl'
-        }
-      },
-      define: {
-        files: {
-          'tmp/define.css': 'test/fixtures/define/define.styl'
-        },
-        options: {
-          define: {
-            var1: 42,
-            var2: 'Helvetica'
-          }
-        }
-      },
-      defineRaw: {
-        files: {
-          'tmp/defineRaw.css': 'test/fixtures/defineRaw/defineRaw.styl'
-        },
-        options: {
-          define: {
-            rawVar: {
-              nestedVar: 42
-            },
-            castedVar: {
-              disc: 'outside'
-            }
-          },
-          // would probably need an option to flag use of raw define
-          rawDefine: ['rawVar']
-        }
-      },
-      resolveUrl: {
-        files: {
-          'tmp/resolveUrl.css': 'test/fixtures/resolveUrl/resolveUrl.styl'
-        },
-        options: {
-          'resolve url': true
-        }
-      },
-      import: {
-        files: {
-        'tmp/import.css': 'test/fixtures/import/import.styl'
-        },
-        options: {
-          paths: ['test/fixtures/'],
-          import: [
-           'include/variables',
-           'nib'
-          ]
-        }
-      },
-      banner: {
-        files: {
-          'tmp/banner.css': 'test/fixtures/banner/banner.styl'
-        },
-        options: {
-          paths: ['test/fixtures/'],
-          banner: '/* test css banner */\n'
-        }
-      },
-      relativeDest: {
-        files: [{
-          expand: true,
-          relativeDest: '/out',
-          src: ['test/fixtures/relativeDest/relativeDest.styl'],
-          dest: 'tmp',
-          ext: '.css'
-        }, {
-          expand: true,
-          relativeDest: '../../',
-          src: ['test/fixtures/relativeDest/relativeDest.styl'],
-          dest: 'tmp',
-          ext: '.css'
-        }]
-      }
-    },
+		// Configuration to be run (and then tested).
+		stylus: {
+			compile: {
+				files: {
+					'tmp/stylus.css': ['test/fixtures/stylus.styl'],
+					'tmp/concat.css': ['test/fixtures/stylus.styl', 'test/fixtures/stylus2.styl']
+				},
+				options: {
+					paths: ['test/fixtures/include'],
+					compress: true
+				}
+			},
+			nib: {
+				files: {
+					'tmp/nib_.css': 'test/fixtures/nib_/nib_.styl'
+				},
+				options: {
+					paths: ['test/fixtures/include']
+				}
+			},
+			autocompress: {
+				files: {
+					'tmp/autocompress.css': 'test/fixtures/stylus.styl'
+				},
+				options: {
+					paths: ['test/fixtures/include']
+				}
+			},
+			plugin: {
+				files: {
+					'tmp/plugin.css': 'test/fixtures/plugin/plugin.styl'
+				},
+				options: {
+					use: [
+						testPlugin,
+						function() {
+							return testPlugin('yep');
+						}
+					]
+				}
+			},
+			embedurl: {
+				files: {
+					'tmp/embedurl.css': 'test/fixtures/embedurl/embedurl.styl'
+				},
+				options: {
+					urlfunc: 'embedurl'
+				}
+			},
+			embedurlObj: {
+				files: {
+					'tmp/embedurlObj.css': 'test/fixtures/embedurl/embedurl.styl'
+				},
+				options: {
+					urlfunc: {
+						name: 'embedurl'
+					}
+				}
+			},
+			urlfuncOpts: {
+				files: {
+					'tmp/embedurlOpts.css': 'test/fixtures/embedurl/embedurlOpts.styl'
+				},
+				options: {
+					urlfunc: {
+						name: 'embedurl',
+						limit: 10,
+						paths: []
+					}
+				}
+			},
+			urlfuncLimitFalse: {
+				files: {
+					'tmp/urlfuncLimitFalse.css': 'test/fixtures/embedurl/urlfuncLimitFalse.styl'
+				},
+				options: {
+					urlfunc: {
+						name: 'embedurl',
+						limit: false,
+						paths: []
+					}
+				}
+			},
+			relative: {
+				files: {
+					'tmp/relative.css': 'test/fixtures/relative/relative.styl'
+				}
+			},
+			define: {
+				files: {
+					'tmp/define.css': 'test/fixtures/define/define.styl'
+				},
+				options: {
+					define: {
+						var1: 42,
+						var2: 'Helvetica'
+					}
+				}
+			},
+			defineRaw: {
+				files: {
+					'tmp/defineRaw.css': 'test/fixtures/defineRaw/defineRaw.styl'
+				},
+				options: {
+					define: {
+						rawVar: {
+							nestedVar: 42
+						},
+						castedVar: {
+							disc: 'outside'
+						}
+					},
+					// would probably need an option to flag use of raw define
+					rawDefine: ['rawVar']
+				}
+			},
+			resolveUrl: {
+				files: {
+					'tmp/resolveUrl.css': 'test/fixtures/resolveUrl/resolveUrl.styl'
+				},
+				options: {
+					'resolve url': true
+				}
+			},
+			import: {
+				files: {
+					'tmp/import.css': 'test/fixtures/import/import.styl'
+				},
+				options: {
+					paths: ['test/fixtures/'],
+					import: [
+						'include/variables',
+						'nib'
+					]
+				}
+			},
+			banner: {
+				files: {
+					'tmp/banner.css': 'test/fixtures/banner/banner.styl'
+				},
+				options: {
+					paths: ['test/fixtures/'],
+					banner: '/* test css banner */\n'
+				}
+			},
+			relativeDestOut: {
+				options: {
+					relativeDest: '/out'
+				},
+				files: [{
+					expand: true,
 
-    // Unit tests.
-    nodeunit: {
-      tests: ['test/*_test.js']
-    }
-  });
+					src: ['test/fixtures/relativeDest/relativeDest.styl'],
+					dest: 'tmp',
+					ext: '.css'
+				}]
 
-  // Actually load this plugin's task(s).
-  grunt.loadTasks('tasks');
+			},
+			relativeDestIn: {
+				options: {
+					relativeDest: '../../'
+				},
+				files: [{
+					expand: true,
+					src: ['test/fixtures/relativeDest/relativeDest.styl'],
+					dest: 'tmp',
+					ext: '.css'
+				}]
+			}
+		},
 
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-nodeunit');
-  grunt.loadNpmTasks('grunt-contrib-internal');
+		// Unit tests.
+		nodeunit: {
+			tests: ['test/*_test.js']
+		}
+	});
 
-  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
-  // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['jshint', 'clean', 'stylus', 'nodeunit']);
+	// Actually load this plugin's task(s).
+	grunt.loadTasks('tasks');
 
-  // By default, lint and run all tests.
-  grunt.registerTask('default', ['test', 'build-contrib']);
+	// These plugins provide necessary tasks.
+	grunt.loadNpmTasks('grunt-contrib-clean');
+	grunt.loadNpmTasks('grunt-contrib-jshint');
+	grunt.loadNpmTasks('grunt-contrib-nodeunit');
+	grunt.loadNpmTasks('grunt-contrib-internal');
+
+	// Whenever the "test" task is run, first clean the "tmp" dir, then run this
+	// plugin's task(s), then test the result.
+	grunt.registerTask('test', ['jshint', 'clean', 'stylus', 'nodeunit']);
+
+	// By default, lint and run all tests.
+	grunt.registerTask('default', ['test', 'build-contrib']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,223 +10,222 @@
 
 module.exports = function(grunt) {
 
-	function testPlugin(param) {
-		param = param || 'nope';
+  function testPlugin(param) {
+    param = param || 'nope';
 
-		return function(style) {
-			style.define('test-plugin', param);
-		};
-	}
+    return function(style) {
+      style.define('test-plugin', param);
+    };
+  }
 
-	// Project configuration.
-	grunt.initConfig({
-		jshint: {
-			all: [
-				'Gruntfile.js',
-				'tasks/*.js',
-				'<%= nodeunit.tests %>'
-			],
-			options: {
-				jshintrc: '.jshintrc'
-			}
-		},
+  // Project configuration.
+  grunt.initConfig({
+    jshint: {
+      all: [
+        'Gruntfile.js',
+        'tasks/*.js',
+        '<%= nodeunit.tests %>'
+      ],
+      options: {
+        jshintrc: '.jshintrc'
+      }
+    },
 
-		// Before generating any new files, remove any previously-created files.
-		clean: {
-			test: ['tmp']
-		},
+    // Before generating any new files, remove any previously-created files.
+    clean: {
+      test: ['tmp']
+    },
 
-		// Configuration to be run (and then tested).
-		stylus: {
-			compile: {
-				files: {
-					'tmp/stylus.css': ['test/fixtures/stylus.styl'],
-					'tmp/concat.css': ['test/fixtures/stylus.styl', 'test/fixtures/stylus2.styl']
-				},
-				options: {
-					paths: ['test/fixtures/include'],
-					compress: true
-				}
-			},
-			nib: {
-				files: {
-					'tmp/nib_.css': 'test/fixtures/nib_/nib_.styl'
-				},
-				options: {
-					paths: ['test/fixtures/include']
-				}
-			},
-			autocompress: {
-				files: {
-					'tmp/autocompress.css': 'test/fixtures/stylus.styl'
-				},
-				options: {
-					paths: ['test/fixtures/include']
-				}
-			},
-			plugin: {
-				files: {
-					'tmp/plugin.css': 'test/fixtures/plugin/plugin.styl'
-				},
-				options: {
-					use: [
-						testPlugin,
-						function() {
-							return testPlugin('yep');
-						}
-					]
-				}
-			},
-			embedurl: {
-				files: {
-					'tmp/embedurl.css': 'test/fixtures/embedurl/embedurl.styl'
-				},
-				options: {
-					urlfunc: 'embedurl'
-				}
-			},
-			embedurlObj: {
-				files: {
-					'tmp/embedurlObj.css': 'test/fixtures/embedurl/embedurl.styl'
-				},
-				options: {
-					urlfunc: {
-						name: 'embedurl'
-					}
-				}
-			},
-			urlfuncOpts: {
-				files: {
-					'tmp/embedurlOpts.css': 'test/fixtures/embedurl/embedurlOpts.styl'
-				},
-				options: {
-					urlfunc: {
-						name: 'embedurl',
-						limit: 10,
-						paths: []
-					}
-				}
-			},
-			urlfuncLimitFalse: {
-				files: {
-					'tmp/urlfuncLimitFalse.css': 'test/fixtures/embedurl/urlfuncLimitFalse.styl'
-				},
-				options: {
-					urlfunc: {
-						name: 'embedurl',
-						limit: false,
-						paths: []
-					}
-				}
-			},
-			relative: {
-				files: {
-					'tmp/relative.css': 'test/fixtures/relative/relative.styl'
-				}
-			},
-			define: {
-				files: {
-					'tmp/define.css': 'test/fixtures/define/define.styl'
-				},
-				options: {
-					define: {
-						var1: 42,
-						var2: 'Helvetica'
-					}
-				}
-			},
-			defineRaw: {
-				files: {
-					'tmp/defineRaw.css': 'test/fixtures/defineRaw/defineRaw.styl'
-				},
-				options: {
-					define: {
-						rawVar: {
-							nestedVar: 42
-						},
-						castedVar: {
-							disc: 'outside'
-						}
-					},
-					// would probably need an option to flag use of raw define
-					rawDefine: ['rawVar']
-				}
-			},
-			resolveUrl: {
-				files: {
-					'tmp/resolveUrl.css': 'test/fixtures/resolveUrl/resolveUrl.styl'
-				},
-				options: {
-					'resolve url': true
-				}
-			},
-			import: {
-				files: {
-					'tmp/import.css': 'test/fixtures/import/import.styl'
-				},
-				options: {
-					paths: ['test/fixtures/'],
-					import: [
-						'include/variables',
-						'nib'
-					]
-				}
-			},
-			banner: {
-				files: {
-					'tmp/banner.css': 'test/fixtures/banner/banner.styl'
-				},
-				options: {
-					paths: ['test/fixtures/'],
-					banner: '/* test css banner */\n'
-				}
-			},
-			relativeDestOut: {
-				options: {
-					relativeDest: '/out'
-				},
-				files: [{
-					expand: true,
+    // Configuration to be run (and then tested).
+    stylus: {
+      compile: {
+        files: {
+          'tmp/stylus.css': ['test/fixtures/stylus.styl'],
+          'tmp/concat.css': ['test/fixtures/stylus.styl', 'test/fixtures/stylus2.styl']
+        },
+        options: {
+          paths: ['test/fixtures/include'],
+          compress: true
+        }
+      },
+      nib: {
+        files: {
+          'tmp/nib_.css': 'test/fixtures/nib_/nib_.styl'
+        },
+        options: {
+          paths: ['test/fixtures/include']
+        }
+      },
+      autocompress: {
+        files: {
+          'tmp/autocompress.css': 'test/fixtures/stylus.styl'
+        },
+        options: {
+          paths: ['test/fixtures/include']
+        }
+      },
+      plugin: {
+        files: {
+          'tmp/plugin.css': 'test/fixtures/plugin/plugin.styl'
+        },
+        options: {
+          use: [
+            testPlugin,
+            function() {
+              return testPlugin('yep');
+            }
+          ]
+        }
+      },
+      embedurl: {
+        files: {
+          'tmp/embedurl.css': 'test/fixtures/embedurl/embedurl.styl'
+        },
+        options: {
+          urlfunc: 'embedurl'
+        }
+      },
+      embedurlObj: {
+        files: {
+          'tmp/embedurlObj.css': 'test/fixtures/embedurl/embedurl.styl'
+        },
+        options: {
+          urlfunc: {
+            name: 'embedurl'
+          }
+        }
+      },
+      urlfuncOpts: {
+        files: {
+          'tmp/embedurlOpts.css': 'test/fixtures/embedurl/embedurlOpts.styl'
+        },
+        options: {
+          urlfunc: {
+            name: 'embedurl',
+            limit: 10,
+            paths: []
+          }
+        }
+      },
+      urlfuncLimitFalse: {
+        files: {
+          'tmp/urlfuncLimitFalse.css': 'test/fixtures/embedurl/urlfuncLimitFalse.styl'
+        },
+        options: {
+          urlfunc: {
+            name: 'embedurl',
+            limit: false,
+            paths: []
+          }
+        }
+      },
+      relative: {
+        files: {
+          'tmp/relative.css': 'test/fixtures/relative/relative.styl'
+        }
+      },
+      define: {
+        files: {
+          'tmp/define.css': 'test/fixtures/define/define.styl'
+        },
+        options: {
+          define: {
+            var1: 42,
+            var2: 'Helvetica'
+          }
+        }
+      },
+      defineRaw: {
+        files: {
+          'tmp/defineRaw.css': 'test/fixtures/defineRaw/defineRaw.styl'
+        },
+        options: {
+          define: {
+            rawVar: {
+              nestedVar: 42
+            },
+            castedVar: {
+              disc: 'outside'
+            }
+          },
+          // would probably need an option to flag use of raw define
+          rawDefine: ['rawVar']
+        }
+      },
+      resolveUrl: {
+        files: {
+          'tmp/resolveUrl.css': 'test/fixtures/resolveUrl/resolveUrl.styl'
+        },
+        options: {
+          'resolve url': true
+        }
+      },
+      import: {
+        files: {
+          'tmp/import.css': 'test/fixtures/import/import.styl'
+        },
+        options: {
+          paths: ['test/fixtures/'],
+          import: [
+            'include/variables',
+            'nib'
+          ]
+        }
+      },
+      banner: {
+        files: {
+          'tmp/banner.css': 'test/fixtures/banner/banner.styl'
+        },
+        options: {
+          paths: ['test/fixtures/'],
+          banner: '/* test css banner */\n'
+        }
+      },
+      relativeDestOut: {
+        options: {
+          relativeDest: '/out'
+        },
+        files: [{
+          expand: true,
+          src: ['test/fixtures/relativeDest/relativeDest.styl'],
+          dest: 'tmp',
+          ext: '.css'
+        }]
 
-					src: ['test/fixtures/relativeDest/relativeDest.styl'],
-					dest: 'tmp',
-					ext: '.css'
-				}]
+      },
+      relativeDestIn: {
+        options: {
+          relativeDest: '../../'
+        },
+        files: [{
+          expand: true,
+          src: ['test/fixtures/relativeDest/relativeDest.styl'],
+          dest: 'tmp',
+          ext: '.css'
+        }]
+      }
+    },
 
-			},
-			relativeDestIn: {
-				options: {
-					relativeDest: '../../'
-				},
-				files: [{
-					expand: true,
-					src: ['test/fixtures/relativeDest/relativeDest.styl'],
-					dest: 'tmp',
-					ext: '.css'
-				}]
-			}
-		},
+    // Unit tests.
+    nodeunit: {
+      tests: ['test/*_test.js']
+    }
+  });
 
-		// Unit tests.
-		nodeunit: {
-			tests: ['test/*_test.js']
-		}
-	});
+  // Actually load this plugin's task(s).
+  grunt.loadTasks('tasks');
 
-	// Actually load this plugin's task(s).
-	grunt.loadTasks('tasks');
+  // These plugins provide necessary tasks.
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-contrib-internal');
 
-	// These plugins provide necessary tasks.
-	grunt.loadNpmTasks('grunt-contrib-clean');
-	grunt.loadNpmTasks('grunt-contrib-jshint');
-	grunt.loadNpmTasks('grunt-contrib-nodeunit');
-	grunt.loadNpmTasks('grunt-contrib-internal');
+  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
+  // plugin's task(s), then test the result.
+  grunt.registerTask('test', ['jshint', 'clean', 'stylus', 'nodeunit']);
 
-	// Whenever the "test" task is run, first clean the "tmp" dir, then run this
-	// plugin's task(s), then test the result.
-	grunt.registerTask('test', ['jshint', 'clean', 'stylus', 'nodeunit']);
-
-	// By default, lint and run all tests.
-	grunt.registerTask('default', ['test', 'build-contrib']);
+  // By default, lint and run all tests.
+  grunt.registerTask('default', ['test', 'build-contrib']);
 
 };

--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ Default: `''`
 
 This string will be prepended to the beginning of the compiled output.
 
+
+##relativeDest
+Type: `String`
+Default: `''`
+
+Path to be joined and resolved with each file dest to get new one. Mostly useful for files specified using wildcards
+For example 
+```js
+relativeDest: 'out',
+files: [{
+   src: ['src/components/*/*.styl'],
+   ext: '.css'
+   }]
+```
+will generate `src/components/*/out/*.css` files.
+
+
 ### Examples
 
 ```js
@@ -118,6 +135,8 @@ stylus: {
   compile: {
     options: {
       paths: ['path/to/import', 'another/to/import'],
+      relativeDest: '../out', //path to be joined and resolved with each file dest to get new one
+                              //mostly useful for files specified using wildcards
       urlfunc: 'embedurl', // use embedurl('test.png') in our code to trigger Data URI embedding
       use: [
         function () {

--- a/docs/stylus-examples.md
+++ b/docs/stylus-examples.md
@@ -5,6 +5,8 @@ stylus: {
   compile: {
     options: {
       paths: ['path/to/import', 'another/to/import'],
+      relativeDest: '../out', //path to be joined and resolved with each file dest to get new one.
+                              //mostly useful for files specified using wildcards
       urlfunc: 'embedurl', // use embedurl('test.png') in our code to trigger Data URI embedding
       use: [
         function () {

--- a/docs/stylus-options.md
+++ b/docs/stylus-options.md
@@ -70,7 +70,10 @@ When including a css file in your app.styl by using @import "style.css", by defa
 Type: `Boolean`  
 Default: `false`
 
-Telling Stylus to generate `url("bar/baz.png")` in the compiled CSS files accordingly from `@import "bar/bar.styl"` and `url("baz.png")`, which makes relative pathes work in Stylus.
+Telling Stylus to generate `url("bar/baz.png")` in the compiled CSS files accordingly from `@import "bar/bar.styl"` and `url("baz.png")`, which makes relative pathes work in Stylus. 
+
+_All urls are resolved relatively to position of resulting `.css` file_
+
 ( **NOTICE:** the object key contains a space `"resolve url"` and Stylus resolves the url only if it finds the provided file )
 
 ## banner
@@ -78,3 +81,18 @@ Type: `String`
 Default: `''`
 
 This string will be prepended to the beginning of the compiled output.
+
+##relativeDest
+Type: `String`
+Default: `''`
+
+Path to be joined and resolved with each file dest to get new one. Mostly useful for files specified using wildcards
+For example 
+```js
+relativeDest: 'out',
+files: [{
+   src: ['src/components/*/*.styl'],
+   ext: '.css'
+   }]
+```
+will generate `src/components/*/out/*.css` files.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chalk": "^1.0.0",
     "lodash": "^3.3.1",
     "nib": "^1.1.0",
-    "stylus": "~0.50.0"
+    "stylus": "^0.51.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "chalk": "^1.0.0",
     "lodash": "^3.3.1",
     "nib": "^1.1.0",
-    "stylus": "^0.51.1"
+    "stylus": "^0.52.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -38,6 +38,8 @@ module.exports = function(grunt) {
         destFile = destFile.replace('//', '/');
       }
 
+      options.dest = destFile;
+
       var srcFiles = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {

--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -33,8 +33,8 @@ module.exports = function(grunt) {
     async.forEachSeries(this.files, function(f, n) {
       var destFile = path.normalize(f.dest);
 
-      if (f.relativeDest) {
-        destFile = path.dirname(f.dest) + '/' + f.relativeDest + '/' + path.basename(f.dest);
+      if (options.relativeDest) {
+        destFile = path.dirname(f.dest) + '/' + options.relativeDest + '/' + path.basename(f.dest);
         destFile = destFile.replace('//', '/');
       }
 

--- a/tasks/stylus.js
+++ b/tasks/stylus.js
@@ -32,6 +32,12 @@ module.exports = function(grunt) {
 
     async.forEachSeries(this.files, function(f, n) {
       var destFile = path.normalize(f.dest);
+
+      if (f.relativeDest) {
+        destFile = path.dirname(f.dest) + '/' + f.relativeDest + '/' + path.basename(f.dest);
+        destFile = destFile.replace('//', '/');
+      }
+
       var srcFiles = f.src.filter(function(filepath) {
         // Warn on and remove invalid source files (if nonull was set).
         if (!grunt.file.exists(filepath)) {

--- a/test/expected/relativeDest/relativeDest.css
+++ b/test/expected/relativeDest/relativeDest.css
@@ -1,0 +1,1 @@
+body{content:test-plugin}

--- a/test/expected/resolveUrl/resolveUrl.css
+++ b/test/expected/resolveUrl/resolveUrl.css
@@ -1,1 +1,1 @@
-body{background:url("child/child.png")}
+body{background:url("../test/fixtures/resolveUrl/child/child.png")}

--- a/test/fixtures/relativeDest/relativeDest.styl
+++ b/test/fixtures/relativeDest/relativeDest.styl
@@ -1,0 +1,2 @@
+body
+  content:test-plugin

--- a/test/stylus_test.js
+++ b/test/stylus_test.js
@@ -127,5 +127,23 @@ exports.stylus = {
     test.equal(expected, actual, 'should resolve import urls');
 
     test.done();
+  },
+  relativeDestIn: function(test) {
+    test.expect(1);
+
+    var actual = readFile('tmp/test/fixtures/relativeDest/out/relativeDest.css');
+    var expected = readFile('test/expected/relativeDest/relativeDest.css');
+    test.equal(expected, actual, 'should generate file with relative dest');
+
+    test.done();
+  },
+  relativeDestOut: function(test) {
+    test.expect(1);
+
+    var actual = readFile('tmp/test/relativeDest.css');
+    var expected = readFile('test/expected/relativeDest/relativeDest.css');
+    test.equal(expected, actual, 'should generate file with relative dest');
+
+    test.done();
   }
 };


### PR DESCRIPTION
Hello!
I've had this problem with stylus url resolving: https://github.com/stylus/stylus/issues/1933 
And figured out your plugin processes all css files to one folder specified in `dest`.
But when my src is like  `src/component/*/in.styl` and i want to generate each .css at `src/component/*/css/out.css`, i should use `rename` to move my files. 
So I made an improvement – now param `relativeDest` can be passed and then all `.css` files will be generated relatively to `dest`.
For example
```
  task: {
        files: [{
          expand: true,
          relativeDest: '/out',
          src: ['test/in.styl'],
          dest: 'tmp',
          ext: '.css'
        },
```
will generate `tmp/test/out/in.css` and, the most important, will provide this path to stylus to let it resolve urls correctly
