### PR TITLE
chore(deps): update dependencies and CI configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
-sudo: false
+os: linux
+
+dist: jammy
+
+git:
+  depth: 1
+
 language: node_js
-node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "5"
-  - "iojs"
-before_install:
-  - if [ "$TRAVIS_NODE_VERSION" = "0.10" ]; then npm install -g npm@2; fi
-matrix:
-  fast_finish: true
+
+node_js: node
+
 cache:
   directories:
-    - node_modules
+  - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,44 +1,30 @@
 # http://www.appveyor.com/docs/appveyor-yml
 
-clone_depth: 10
+platform: x64
+
+image: Visual Studio 2022
+
+clone_depth: 1
 
 version: "{build}"
 
 # What combinations to test
 environment:
-  matrix:
-    - nodejs_version: "0.10"
-      platform: x86
-    - nodejs_version: "0.12"
-      platform: x86
-    - nodejs_version: "4"
-      platform: x64
-    - nodejs_version: "4"
-      platform: x86
-    - nodejs_version: "5"
-      platform: x86
+  nodejs_version: "21"
 
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: >-
-      if ($env:nodejs_version -eq "0.10") {
-        npm -g install npm@2
-        $env:PATH="$env:APPDATA\npm;$env:PATH"
-      }
-  - npm install
+- ps: Install-Product node $env:nodejs_version
+- npm install
 
 test_script:
-  # Output useful info for debugging
-  - node --version && npm --version
-  # We test multiple Windows shells because of prior stdout buffering issues
-  # filed against Grunt. https://github.com/joyent/node/issues/3584
-  - ps: "npm test # PowerShell" # Pass comment to PS for easier debugging
-  - cmd: npm test
+# Output useful info for debugging
+- node --version && npm --version
+# We test multiple Windows shells because of prior stdout buffering issues
+# filed against Grunt. https://github.com/joyent/node/issues/3584
+- ps: "npm test # PowerShell" # Pass comment to PS for easier debugging
+- cmd: npm test
 
 build: off
 
-matrix:
-  fast_finish: true
-
 cache:
-  - node_modules -> package.json
+- node_modules -> package.json

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "^3.2.5",
-    "chalk": "^5.3.0",
+    "chalk": "^4.1.2",
     "lodash": "^4.17.21",
     "nib": "^1.2.0",
     "stylus": "^0.62.0"

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "^1.5.2",
-    "chalk": "^1.0.0",
-    "lodash": "^4.0.0",
-    "nib": "^1.1.0",
-    "stylus": "^0.54.0"
+    "async": "^3.2.5",
+    "chalk": "^5.3.0",
+    "lodash": "^4.17.21",
+    "nib": "^1.2.0",
+    "stylus": "^0.62.0"
   },
   "devDependencies": {
-    "grunt": "^1.0.0",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-internal": "^1.1.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-nodeunit": "^1.0.0"
+    "grunt": "^1.6.1",
+    "grunt-contrib-clean": "^2.0.1",
+    "grunt-contrib-internal": "^9.0.0",
+    "grunt-contrib-jshint": "^3.2.0",
+    "grunt-contrib-nodeunit": "^5.0.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
### 1. Purpose

The version of Stylus in the grunt-contrib-stylus plugin is too old. Using grunt-contrib-stylus, I cannot use Stylus features introduced in the 8 years since version 0.54.0 was released, and I get bugs fixed during this time.

I updated the Stylus dependency and updated everything else along the way.

### 2. Dependencies

I updated all dependencies and devDependencies in `package.json` except [**Chalk**](https://www.npmjs.com/package/chalk). Chalk 5 and higher is [**pure ESM**](https://www.npmjs.com/package/chalk#install), [**4.1.2 is the latest not pure ESM version**](https://stackoverflow.com/a/70425265/5951529).

### 3. CI

1. I dropped support of io.js and old Node.js versions. Instead, I added support for the latest version of Node.js at the time of writing this pull request — Node.js 21.
1. I have added support for the latest CI images at the time of writing this pull request — [**Jammy 22.04 Travis Ubuntu image**](https://docs.travis-ci.com/user/reference/linux/) and [**Visual Studio 2022 AppVeyor Windows image**](https://www.appveyor.com/docs/windows-images-software/)

Thanks.
